### PR TITLE
update scripts, fixes and input as apk

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,4 +103,4 @@ python blutter.py path\to\lib\arm64-v8a build\vs --vs-sln
   - Object modification
 - Obfuscated app (still missing many functions)
 - Reading iOS binary
-- Input as apk or ipa
+- Input as ipa

--- a/blutter.py
+++ b/blutter.py
@@ -7,6 +7,8 @@ import platform
 import shutil
 import subprocess
 import sys
+import zipfile
+import tempfile
 
 CMAKE_CMD = "cmake"
 NINJA_CMD = "ninja"
@@ -33,6 +35,21 @@ def find_lib_files(indir: str):
 
     return os.path.abspath(app_file), os.path.abspath(flutter_file)
 
+def extract_libs_from_apk(apk_file):
+    with zipfile.ZipFile(apk_file, 'r') as zip_ref:
+        lib_files = [name for name in zip_ref.namelist() if name.startswith('lib/') and name.endswith('.so')]
+        if not lib_files:
+            sys.exit("Cannot find libapp.so or libflutter.so in the APK")
+
+        temp_dir = tempfile.mkdtemp()
+        print("libs are extracted to:", temp_dir)
+        extracted_files = []
+
+        for lib_file in lib_files:
+            zip_ref.extract(lib_file, temp_dir)
+            extracted_files.append(os.path.join(temp_dir, lib_file))
+
+        return temp_dir, extracted_files
 
 def find_compat_macro(dart_version: str, no_analysis: bool):
     macros = []
@@ -131,7 +148,14 @@ def main(
     create_vs_sln: bool,
     no_analysis: bool,
 ):
-    libapp_file, libflutter_file = find_lib_files(indir)
+    if indir.endswith('.apk'):
+        indir, extracted_files = extract_libs_from_apk(indir)
+        libapp_file = next((f for f in extracted_files if "libapp.so" in f), None)
+        libflutter_file = next((f for f in extracted_files if "libflutter.so" in f), None)
+        if not libapp_file or not libflutter_file:
+            sys.exit("Cannot find libapp.so or libflutter.so in the APK")
+    else:
+        libapp_file, libflutter_file = find_lib_files(indir)
 
     # getting dart version
     from extract_dart_info import extract_dart_info
@@ -255,7 +279,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="B(l)utter", description="Reversing a flutter application tool"
     )
-    # TODO: accept apk or ipa
+    # TODO: accept ipa
     parser.add_argument(
         "indir",
         help="A directory directory that contains both libapp.so and libflutter.so",

--- a/blutter/src/CodeAnalyzer.cpp
+++ b/blutter/src/CodeAnalyzer.cpp
@@ -46,6 +46,10 @@ std::string FnParamInfo::ToString() const
 	}
 	if (valReg.IsSet() || localOffset) {
 		txt += " /* ";
+		if (paramReg.IsSet()) {
+			txt += paramReg.Name();
+			txt += " => ";
+		}
 		if (valReg.IsSet()) {
 			txt += valReg.Name();
 			if (localOffset)

--- a/blutter/src/CodeAnalyzer.h
+++ b/blutter/src/CodeAnalyzer.h
@@ -60,11 +60,16 @@ private:
 };
 
 struct FnParamInfo {
+	A64::Register paramReg; // when parameter is passed with register
+	int32_t paramOffset{ 0 }; // offset from FP (first param offset is 0x10. if it is optional param, value is 0)
 	A64::Register valReg;
 	int32_t localOffset{ 0 }; // offset from FP (local variable)
 	DartType* type{ nullptr };
 	std::string name;
 	std::unique_ptr<VarValue> val;
+
+	explicit FnParamInfo() {}
+	explicit FnParamInfo(A64::Register paramReg, A64::Register valReg, int32_t localOffset) : paramReg(paramReg), valReg(valReg), localOffset(localOffset) {}
 	explicit FnParamInfo(A64::Register valReg) : valReg(valReg) {}
 	explicit FnParamInfo(A64::Register valReg, int32_t localOffset) : valReg(valReg), localOffset(localOffset) {}
 	explicit FnParamInfo(A64::Register valReg, std::unique_ptr<VarValue> val) : valReg(valReg), val(std::move(val)) {}
@@ -81,6 +86,7 @@ struct FnParams {
 	int NumOptionalParam() const { return params.size() - numFixedParam; }
 	bool empty() const { return params.empty(); }
 	void add(FnParamInfo&& param) { params.push_back(std::move(param)); }
+	void addFixedParam(FnParamInfo&& param) { params.push_back(std::move(param)); numFixedParam++; }
 	FnParamInfo& back() { return params.back(); }
 	FnParamInfo& operator[](int i) { return params[i]; }
 

--- a/blutter/src/CodeAnalyzer_arm64.cpp
+++ b/blutter/src/CodeAnalyzer_arm64.cpp
@@ -212,6 +212,7 @@ public:
 	void handleOptionalPositionalParameters(AsmIterator& insn, arm64_reg optionalParamCntReg);
 	void handleOptionalNamedParameters(AsmIterator& insn, arm64_reg paramCntReg);
 	void handleArgumentsDescriptorTypeArguments(AsmIterator& insn);
+	void handleParameterRegisters(AsmIterator& insn);
 
 	StoreLocalResult handleStoreLocal(AsmIterator& insn, arm64_reg expected_src_reg = ARM64_REG_INVALID);
 
@@ -917,7 +918,7 @@ void FunctionAnalyzer::handleOptionalPositionalParameters(AsmIterator& insn, arm
 			}
 		}
 		else {
-			fnInfo->params.add(FnParamInfo{ A64::Register{} });
+			fnInfo->params.add(FnParamInfo{});
 		}
 
 		++i;
@@ -1537,6 +1538,119 @@ void FunctionAnalyzer::handleArgumentsDescriptorTypeArguments(AsmIterator& insn)
 	fnInfo->State()->ClearRegister(fnInfo->typeArgumentReg);
 }
 
+// parameter registers are same as arm64 call convention exception R0 and R4 are reserved
+static const A64::Register allowedParameterRegisters[] = {
+	A64::Register::R1, A64::Register::R2, A64::Register::R3,
+	A64::Register::R5, A64::Register::R6, A64::Register::R7,
+	A64::Register::V0, A64::Register::V1, A64::Register::V2, A64::Register::V3,
+	A64::Register::V4, A64::Register::V5, A64::Register::V6, A64::Register::V7,
+};
+
+static bool isAllowedParameterRegister(A64::Register reg)
+{
+	const auto eptr = std::end(allowedParameterRegisters);
+	return std::find(std::begin(allowedParameterRegisters), eptr, reg) != eptr;
+}
+
+void FunctionAnalyzer::handleParameterRegisters(AsmIterator& insn)
+{
+	// since Dart 3.4, some function call might use register for passing parameters
+	// these parameter registers are always stored into stack before using
+
+	// assume there is only 2 cases
+	// - mov to dstReg
+	// - mov to TMP then mov to dstReg
+	struct TmpParamReg {
+		A64::Register reg;
+		int localOffset;
+		A64::Register dstReg;
+	};
+	std::vector<TmpParamReg> paramRegs;
+	const auto getParamReg = [&](A64::Register reg) -> TmpParamReg& {
+		// check from dstReg first because it is the current owner
+		for (auto& param : paramRegs) {
+			if (param.dstReg == reg)
+				return param;
+		}
+		// next from srcReg in case of previous used
+		for (auto& param : paramRegs) {
+			if (param.reg == reg)
+				return param;
+		}
+		paramRegs.push_back(TmpParamReg{ .reg = reg });
+		return paramRegs.back();
+	};
+
+	while (true) {
+		// Note: no need to check register is not defined before used because this function is called before any register is set
+		if (insn.id() == ARM64_INS_MOV && insn.ops(1).type == ARM64_OP_REG && insn.ops(1).reg != CSREG_DART_NULL) {
+			// src must be undefined
+			const A64::Register srcReg = insn.ops(1).reg;
+			const A64::Register dstReg = insn.ops(0).reg;
+
+			const bool isTmpReg = srcReg == A64::Register::TMP || srcReg == A64::Register::VTMP;
+			if (!isTmpReg && !isAllowedParameterRegister(srcReg))
+				break;
+
+			auto& param = getParamReg(srcReg);
+			if (param.dstReg.IsSet()) {
+				// dstReg is already set. if using same source, ignore them
+				// TODO: multiple dstReg
+				if (param.reg == srcReg) {
+					++insn;
+					continue;
+				}
+				INSN_ASSERT(param.dstReg == srcReg);
+			}
+			else {
+				// tmp reg cannot be found from parameter register
+				INSN_ASSERT(!isTmpReg);
+			}
+			param.dstReg = dstReg;
+
+			++insn;
+		}
+		else if (insn.id() == ARM64_INS_STUR && insn.ops(1).mem.base == CSREG_DART_FP && insn.ops(1).mem.disp < 0) {
+			// src must be undefined, but might be used with mov instruction
+			const A64::Register srcReg = insn.ops(0).reg;
+			if (fnInfo->State()->GetValue(srcReg) != nullptr || !isAllowedParameterRegister(srcReg))
+				break;
+
+			const int offset = insn.ops(1).mem.disp;
+			auto& param = getParamReg(srcReg);
+			INSN_ASSERT(param.localOffset == 0);
+			param.localOffset = offset;
+			++insn;
+		}
+		else {
+			break;
+		}
+	}
+
+	if (!paramRegs.empty()) {
+		// sort paramRegs first
+		std::ranges::sort(paramRegs, {}, &TmpParamReg::reg);
+
+		for (auto& tmpParam : paramRegs) {
+			// TODO: parameter argument MUST be used in order
+			const auto argIdx = fnInfo->params.numFixedParam;
+			auto val = fnInfo->Vars()->ValParam(argIdx);
+			// if src register is moved, just set value to dst register
+			if (tmpParam.localOffset != 0)
+				fnInfo->State()->SetLocal(tmpParam.localOffset, val);
+			fnInfo->State()->SetRegister(tmpParam.dstReg.IsSet() ? tmpParam.dstReg : tmpParam.reg, val);
+			// TODO: useless to set localOffset here
+			fnInfo->params.addFixedParam(FnParamInfo{ tmpParam.reg, tmpParam.dstReg, tmpParam.localOffset });
+		}
+
+		if (!dartFn->IsStatic() && paramRegs[0].reg == A64::Register::R1) {
+			// class method. first parameter is "this"
+			fnInfo->params[0].name = "this";
+			fnInfo->params[0].type = dartFn->Class().DeclarationType(); // TODO: class with type arguments (generic class)
+		}
+	}
+}
+
 std::unique_ptr<SetupParametersInstr> FunctionAnalyzer::processPrologueParametersInstr(AsmIterator& insn, uint64_t endPrologueAddr)
 {
 	// reversing of PrologueBuilder::BuildPrologue() which compose of 3 functions
@@ -1615,22 +1729,28 @@ std::unique_ptr<SetupParametersInstr> FunctionAnalyzer::processPrologueParameter
 		//   there is also a case when setting fixed param count to 0 and using ArgumentsDescriptor (mov x1, x4)
 		//   e.g. package:flutter/src/foundation/_isolates_io.dart (compute function)
 		//   e.g. package:flutter/src/services/platform_channel.dart (compute MethodChannel::_invokeMethod)
-	}
-	else if (dartFn->IsClosure()) {
-		handleInitialization();
 
-		// if no saving function arguments (no optional parameter), a first argument MUST be loaded first.
-		if (insn.id() == ARM64_INS_LDR && insn.ops(1).mem.base == CSREG_DART_FP && insn.ops(1).mem.disp > 0) {
-			const auto firstParamOffset = insn.ops(1).mem.disp;
-			// function might have multiple parameter but the function uses only last parameter
-			// so, below detection might be wrong
-			if (!mightBeFirstParamOffset(firstParamOffset))
-				return nullptr;
-			firstParamReg = insn.ops(0).reg;
-			// Note: this might not be first function argument
-			fnInfo->State()->SetRegister(A64::Register{ insn.ops(0).reg }, fnInfo->Vars()->ValParam(0));
-			//const int numParam = ((firstParamOffset - 0x10) / sizeof(void*)) + 1;
-			++insn;
+		handleParameterRegisters(insn);
+	}
+	else {
+		handleParameterRegisters(insn);
+
+		if (dartFn->IsClosure()) {
+			handleInitialization();
+
+			// if no saving function arguments (no optional parameter), a first argument MUST be loaded first.
+			if (insn.id() == ARM64_INS_LDR && insn.ops(1).mem.base == CSREG_DART_FP && insn.ops(1).mem.disp > 0) {
+				const auto firstParamOffset = insn.ops(1).mem.disp;
+				// function might have multiple parameter but the function uses only last parameter
+				// so, below detection might be wrong
+				if (!mightBeFirstParamOffset(firstParamOffset))
+					return nullptr;
+				firstParamReg = insn.ops(0).reg;
+				// Note: this might not be first function argument
+				fnInfo->State()->SetRegister(A64::Register{ insn.ops(0).reg }, fnInfo->Vars()->ValParam(0));
+				//const int numParam = ((firstParamOffset - 0x10) / sizeof(void*)) + 1;
+				++insn;
+			}
 		}
 	}
 
@@ -1670,7 +1790,7 @@ std::unique_ptr<SetupParametersInstr> FunctionAnalyzer::processPrologueParameter
 		return argsDescReg;
 	}();
 
-	if (argsDescReg == ARM64_REG_INVALID && !needSuspendState && !dartFn->IsClosure())
+	if (argsDescReg == ARM64_REG_INVALID && !needSuspendState && !dartFn->IsClosure() && fnInfo->params.empty())
 		return nullptr;
 
 	int fixedParamCnt = 0;
@@ -1876,35 +1996,12 @@ std::unique_ptr<SetupParametersInstr> FunctionAnalyzer::processPrologueParameter
 	}
 
 	if (insn.address() < endPrologueAddr) {
-		const auto addRegisterFunctionParameter = [&](A64::Register srcReg) {
-			// only R1, R2 and R3 for function arguments
-			INSN_ASSERT(srcReg == A64::Register::R1 || srcReg == A64::Register::R2 || srcReg == A64::Register::R3);
-			const auto argIdx = (int)srcReg - 1;
-			auto val = fnInfo->Vars()->ValParam(argIdx);
-			// set srcReg as function argument (previous should be nullptr)
-			fnInfo->State()->SetRegister(srcReg, val);
-			// assume register argument is used in order
-			INSN_ASSERT(fnInfo->params.NumParam() == argIdx);
-			auto paramInfo = FnParamInfo{ srcReg };
-			if (!dartFn->IsStatic() && argIdx == 0) {
-				// class method. first parameter is "this"
-				paramInfo.name = "this";
-				paramInfo.type = dartFn->Class().DeclarationType(); // TODO: class with type arguments (generic class)
-			}
-			fnInfo->params.add(std::move(paramInfo));
-			fnInfo->params.numFixedParam = argIdx + 1;
-			return val;
-		};
-
 		// moving registers
 		while (insn.id() == ARM64_INS_MOV && insn.ops(1).type == ARM64_OP_REG && insn.ops(1).reg != CSREG_DART_NULL) {
 			const A64::Register srcReg = insn.ops(1).reg;
 			const A64::Register dstReg = insn.ops(0).reg;
 			const auto val = fnInfo->State()->MoveRegister(dstReg, srcReg);
-			if (val == nullptr) {
-				auto val = addRegisterFunctionParameter(srcReg);
-				fnInfo->State()->SetRegister(dstReg, val);
-			}
+			INSN_ASSERT(val != nullptr);
 			++insn;
 		}
 		// before CheckStackOverflow, there might be loading paramters into registers and storing some register to local stack
@@ -1939,11 +2036,9 @@ std::unique_ptr<SetupParametersInstr> FunctionAnalyzer::processPrologueParameter
 			else {
 				auto val = fnInfo->State()->GetValue(srcReg);
 				if (val == nullptr) {
-					//std::cout << fmt::format("Cannot find define of srcReg\n");
-					//auto ins = insn.Current() - 1;
-					//std::cout << fmt::format("  {:#x}: {} {}\n", ins->address, &ins->mnemonic[0], &ins->op_str[0]);
-					INSN_ASSERT(dartFn->IsClosure() || needSuspendState);
-					val = addRegisterFunctionParameter(srcReg);
+					std::cout << fmt::format("Cannot find define of srcReg\n");
+					auto ins = insn.Current() - 1;
+					std::cout << fmt::format("  {:#x}: {} {}\n", ins->address, &ins->mnemonic[0], &ins->op_str[0]);
 				}
 				fnInfo->State()->SetLocal(storeRes.fpOffset, val);
 			}

--- a/blutter/src/DartDumper.cpp
+++ b/blutter/src/DartDumper.cpp
@@ -32,21 +32,33 @@ static std::string getFunctionName4Ida(const DartFunction& dartFn, const std::st
 		return "_anon_closure";
 	}
 
+	auto periodPos = fnName.find('.');
+	std::string prefix;
+	if (dartFn.IsStatic() && dartFn.Kind() == DartFunction::NORMAL && periodPos != std::string::npos) {
+		// this one is extension
+		prefix = fnName.substr(0, periodPos + 1);
+		if (prefix.starts_with("_extension#")) {
+			// anonymous extension. '#' is invalid name in IDA.
+			std::replace(prefix.begin(), prefix.end(), '#', '@');
+		}
+		fnName = fnName.substr(periodPos + 1);
+	}
+
 	if (OP_MAP.contains(fnName)) {
-		return "op_" + OP_MAP[fnName];
+		return prefix + "op_" + OP_MAP[fnName];
 	}
 	const auto last = fnName.back();
 	if (last == '=') {
 		fnName.pop_back();
-		return fnName + "_assign";
+		return prefix + fnName + "_assign";
 	}
 	else if (last == '-') {
 		fnName.pop_back();
-		return fnName + "_neg";
+		return prefix + fnName + "_neg";
 	}
 	else if (last == '!') {
 		fnName.pop_back();
-		return fnName + "_not";
+		return prefix + fnName + "_not";
 	}
 
 	switch (dartFn.Kind()) {
@@ -67,7 +79,7 @@ static std::string getFunctionName4Ida(const DartFunction& dartFn, const std::st
 		break;
 	}
 
-	return fnName;
+	return prefix + fnName;
 }
 
 void DartDumper::Dump4Radare2(std::filesystem::path outDir)
@@ -86,15 +98,21 @@ void DartDumper::Dump4Radare2(std::filesystem::path outDir)
 
 		std::replace(lib_prefix.begin(), lib_prefix.end(), '$', '_');
 		std::replace(lib_prefix.begin(), lib_prefix.end(), '&', '_');
+		std::replace(lib_prefix.begin(), lib_prefix.end(), '-', '_');
+		std::replace(lib_prefix.begin(), lib_prefix.end(), '+', '_');
 		for (auto cls : lib->classes) {
 			std::string cls_prefix = cls->Name();
 			std::replace(cls_prefix.begin(), cls_prefix.end(), '$', '_');
 			std::replace(cls_prefix.begin(), cls_prefix.end(), '&', '_');
+			std::replace(cls_prefix.begin(), cls_prefix.end(), '-', '_');
+			std::replace(cls_prefix.begin(), cls_prefix.end(), '+', '_');
 			for (auto dartFn : cls->Functions()) {
 				const auto ep = dartFn->Address();
 				auto name = getFunctionName4Ida(*dartFn, cls_prefix);
 				std::replace(name.begin(), name.end(), '$', '_');
 				std::replace(name.begin(), name.end(), '&', '_');
+				std::replace(name.begin(), name.end(), '-', '_');
+				std::replace(name.begin(), name.end(), '+', '_');
 				if (show_library) {
 					of << fmt::format("CC Library({:#x}) = {} @ {}\n", lib->id, lib_prefix, ep);
 					of << fmt::format("f lib.{}={:#x} # {:#x}\n", lib_prefix, ep, lib->id);

--- a/blutter/src/DartLoader.cpp
+++ b/blutter/src/DartLoader.cpp
@@ -49,6 +49,7 @@ static Dart_Isolate load_isolate(const uint8_t* isolate_snapshot_data, const uin
 	if (pos == NULL) {
 		// dart 3 is always null safety, it's ok to consider null-safety to be present, blutter isn't able to find it
 		// in some of dev versions starting 3.5.0-xx-dev from snapshot data
+		// maybe because of -silent-null-safety haven't checked carefully
 	    std::cout << "Cannot find null-safety text. Setting null_safety to true." << std::endl;
 	    flags.null_safety = true;
 	} else {

--- a/blutter/src/DartLoader.cpp
+++ b/blutter/src/DartLoader.cpp
@@ -46,10 +46,15 @@ static Dart_Isolate load_isolate(const uint8_t* isolate_snapshot_data, const uin
 	// dart 3 is always null safety
 	// null safety is enabled by default on Flutter 2.0 with Dart 2.12 (since April 2021)
 	auto pos = strstr((const char*)isolate_snapshot_data + 0x30, "null-safety");
-	if (pos == NULL)
-		throw std::runtime_error("Cannot find null-safety text");
-	// "no-null-safety" is set when null safety is disabled. So check for space
-	flags.null_safety = pos[-1] == ' ';
+	if (pos == NULL) {
+		// dart 3 is always null safety, it's ok to consider null-safety to be present, blutter isn't able to find it
+		// in some of dev versions starting 3.5.0-xx-dev
+	    std::cout << "Cannot find null-safety text. Setting null_safety to true." << std::endl;
+	    flags.null_safety = true;
+	} else {
+	    // "no-null-safety" is set when null safety is disabled. So check for space
+	    flags.null_safety = pos[-1] == ' ';
+	}
 
 	auto isolate = Dart_CreateIsolateGroup(nullptr, nullptr, isolate_snapshot_data,
 		isolate_snapshot_instructions, &flags,

--- a/blutter/src/DartLoader.cpp
+++ b/blutter/src/DartLoader.cpp
@@ -48,7 +48,7 @@ static Dart_Isolate load_isolate(const uint8_t* isolate_snapshot_data, const uin
 	auto pos = strstr((const char*)isolate_snapshot_data + 0x30, "null-safety");
 	if (pos == NULL) {
 		// dart 3 is always null safety, it's ok to consider null-safety to be present, blutter isn't able to find it
-		// in some of dev versions starting 3.5.0-xx-dev
+		// in some of dev versions starting 3.5.0-xx-dev from snapshot data
 	    std::cout << "Cannot find null-safety text. Setting null_safety to true." << std::endl;
 	    flags.null_safety = true;
 	} else {

--- a/blutter/src/DartLoader.cpp
+++ b/blutter/src/DartLoader.cpp
@@ -49,7 +49,6 @@ static Dart_Isolate load_isolate(const uint8_t* isolate_snapshot_data, const uin
 	if (pos == NULL) {
 		// dart 3 is always null safety, it's ok to consider null-safety to be present, blutter isn't able to find it
 		// in some of dev versions starting 3.5.0-xx-dev from snapshot data
-		// maybe because of -silent-null-safety haven't checked carefully
 	    std::cout << "Cannot find null-safety text. Setting null_safety to true." << std::endl;
 	    flags.null_safety = true;
 	} else {

--- a/blutter/src/Disassembler_arm64.h
+++ b/blutter/src/Disassembler_arm64.h
@@ -276,6 +276,10 @@ public:
 	constexpr bool operator==(Value v) const { return reg == v; }
 	constexpr bool operator!=(Value v) const { return reg != v; }
 
+	inline bool Clear() {
+		return reg = kNoRegister;
+	}
+
 	inline bool IsSet() const {
 		return reg != kNoRegister;
 	}
@@ -379,7 +383,7 @@ public:
 		return insn->id == ARM64_INS_MOVZ || (insn->id == ARM64_INS_MOV && op_count() == 2 && ops[1].type == ARM64_OP_IMM);
 	}
 	bool IsBranch(arm64_cc cond = ARM64_CC_INVALID) { return insn->id == ARM64_INS_B && cc() == cond; }
-	bool IsDartArrayLoad() {
+	bool IsDartArrayLoad() const {
 		if (writeback())
 			return false;
 		switch (insn->id) {
@@ -394,7 +398,7 @@ public:
 			return 1;
 		return GetCsRegSize(ops[0].reg);
 	}
-	bool IsDartArrayStore() {
+	bool IsDartArrayStore() const {
 		if (writeback())
 			return false;
 		switch (insn->id) {


### PR DESCRIPTION
* Updated IDA Script
* Radare2 Script wrong flagnames
* fix: Dart 3.5 removed `null_safety` flag
* fix: Wrongly handled registers as fcn. parameters
* TODO: input as apk
![image](https://github.com/dedshit/blutter-termux/assets/85984486/10fdafb0-abb3-4667-be9d-504cf57966b4)

