### PR TITLE
Install Instructions, Code Cleanup, r2_script and DART_COMPRESSED_POINTERS Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ I recommend using Linux OS (only tested on Deiban sid/trixie) because it is easy
 - Install build tools and depenencies
 ```
 apt install python3-pyelftools python3-requests git cmake ninja-build \
-    build-essential pkg-config libicu-dev libcapstone-dev
+    build-essential pkg-config libicu-dev libcapstone-dev libfmt-dev
 ```
 
 ### Windows
 - Install git and python 3
 - Install latest Visual Studio with "Desktop development with C++" and "C++ CMake tools"
-- Install required libraries (libcapstone and libicu4c)
+- Install required libraries (libcapstone, libicu4c and fmt)
 ```
 python scripts\init_env_win.py
 ```
@@ -57,7 +57,7 @@ python scripts\init_env_win.py
 - Install XCode
 - Install clang 16 and required tools
 ```
-brew install llvm@16 cmake ninja pkg-config icu4c capstone
+brew install llvm@16 cmake ninja pkg-config icu4c capstone fmt
 pip3 install pyelftools requests
 ```
 

--- a/blutter.py
+++ b/blutter.py
@@ -352,9 +352,6 @@ def check_for_updates_and_pull():
         # Pull the changes from the remote repository
         run_command("git pull")
 
-        # Replace 'std::format' with 'fmt::format' in all files
-        run_command("find -type f -exec sed -i 's/std::format/fmt::format/g' {} +")
-
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(

--- a/blutter/src/CodeAnalyzer_arm64.cpp
+++ b/blutter/src/CodeAnalyzer_arm64.cpp
@@ -180,7 +180,9 @@ static VarValue* getPoolObject(DartApp& app, intptr_t offset, A64::Register dstR
 static inline void handleDecompressPointer(AsmIterator& insn, arm64_reg reg) {
 	INSN_ASSERT(insn.id() == ARM64_INS_ADD);
 	INSN_ASSERT(insn.ops(0).reg == insn.ops(1).reg && insn.ops(0).reg == reg);
+#if defined(DART_COMPRESSED_POINTERS)
 	INSN_ASSERT(insn.ops(2).reg == CSREG_DART_HEAP && insn.ops(2).shift.value == 32);
+#endif
 	++insn;
 }
 
@@ -2201,6 +2203,7 @@ std::unique_ptr<MoveRegInstr> FunctionAnalyzer::processMoveRegInstr(AsmIterator&
 
 std::unique_ptr<DecompressPointerInstr> FunctionAnalyzer::processDecompressPointerInstr(AsmIterator& insn)
 {
+#if defined(DART_COMPRESSED_POINTERS)
 	if (insn.id() == ARM64_INS_ADD && insn.ops(2).reg == CSREG_DART_HEAP && insn.ops(2).shift.value == 32) {
 		INSN_ASSERT(insn.ops(0).reg == insn.ops(1).reg);
 		const auto reg = A64::Register{ insn.ops(0).reg };
@@ -2208,6 +2211,7 @@ std::unique_ptr<DecompressPointerInstr> FunctionAnalyzer::processDecompressPoint
 		++insn;
 		return std::make_unique<DecompressPointerInstr>(insn.Wrap(ins0_addr), reg);
 	}
+#endif
 	return nullptr;
 }
 
@@ -2959,7 +2963,9 @@ std::unique_ptr<WriteBarrierInstr> FunctionAnalyzer::processWriteBarrierInstr(As
 
 	INSN_ASSERT(insn.id() == ARM64_INS_TST);
 	INSN_ASSERT(insn.ops(0).reg == CSREG_DART_TMP);
+#if defined(DART_COMPRESSED_POINTERS)
 	INSN_ASSERT(insn.ops(1).reg == CSREG_DART_HEAP);
+#endif
 	INSN_ASSERT(insn.ops(1).shift.type == ARM64_SFT_LSR && insn.ops(1).shift.value == 32);
 	++insn;
 

--- a/blutter/src/DartDumper.cpp
+++ b/blutter/src/DartDumper.cpp
@@ -135,8 +135,8 @@ void DartDumper::Dump4Radare2(std::filesystem::path outDir)
 	
 	// app base & heap base address values changes on every run i.e, setting flag names for them is of no use
 
-	// of << std::format("f app.base = {:#x}\n", app.base());
-	// of << std::format("f app.heap_base = {:#x}\n", app.heap_base());
+	// of << fmt::format("f app.base = {:#x}\n", app.base());
+	// of << fmt::format("f app.heap_base = {:#x}\n", app.heap_base());
 
 	bool show_library = true;
 	bool show_class = true;
@@ -162,20 +162,20 @@ void DartDumper::Dump4Radare2(std::filesystem::path outDir)
 				std::replace(name.begin(), name.end(), '+', '_');
 				std::replace(name.begin(), name.end(), '?', '_');
 				if (show_library) {
-					of << std::format("CC Library({:#x}) = {} @ {}\n", lib->id, lib_prefix, ep);
-					of << std::format("f lib.{}={:#x} # {:#x}\n", lib_prefix, ep, lib->id);
+					of << fmt::format("CC Library({:#x}) = {} @ {}\n", lib->id, lib_prefix, ep);
+					of << fmt::format("f lib.{}={:#x} # {:#x}\n", lib_prefix, ep, lib->id);
 					show_library = false;
 				}
 				if (show_class) {
-					of << std::format("CC Class({:#x}) = {} @ {}\n", cls->Id(), cls_prefix, ep);
-					of << std::format("f class.{}.{}={:#x} # {:#x}\n", lib_prefix, cls_prefix, ep, cls->Id());
+					of << fmt::format("CC Class({:#x}) = {} @ {}\n", cls->Id(), cls_prefix, ep);
+					of << fmt::format("f class.{}.{}={:#x} # {:#x}\n", lib_prefix, cls_prefix, ep, cls->Id());
 					show_class = false;
 				}
-				of << std::format("f method.{}.{}.{}_{:x}={:#x}\n", lib_prefix, cls_prefix, name.c_str(), ep, ep);
+				of << fmt::format("f method.{}.{}.{}_{:x}={:#x}\n", lib_prefix, cls_prefix, name.c_str(), ep, ep);
 				if (dartFn->HasMorphicCode()) {
-					of << std::format("f method.{}.{}.{}.miss={:#x}\n", lib_prefix, cls_prefix, name.c_str(), 
+					of << fmt::format("f method.{}.{}.{}.miss={:#x}\n", lib_prefix, cls_prefix, name.c_str(), 
 							dartFn->PayloadAddress());
-					of << std::format("f method.{}.{}.{}.check={:#x}\n", lib_prefix, cls_prefix, name.c_str(), 
+					of << fmt::format("f method.{}.{}.{}.check={:#x}\n", lib_prefix, cls_prefix, name.c_str(), 
 							dartFn->MonomorphicAddress());
 				}
 			}
@@ -198,7 +198,7 @@ void DartDumper::Dump4Radare2(std::filesystem::path outDir)
 		std::replace(name.begin(), name.end(), '?', '_');
 		std::replace(name.begin(), name.end(), '(', '_'); // https://github.com/AbhiTheModder/blutter-termux/issues/6
 		std::replace(name.begin(), name.end(), ')', '_');
-		of << std::format("f method.stub.{}_{:x}={:#x}\n", name.c_str(), ep, ep);
+		of << fmt::format("f method.stub.{}_{:x}={:#x}\n", name.c_str(), ep, ep);
 	}
 
 	of << "f pptr=x27\n"; // TODO: hardcoded value


### PR DESCRIPTION
- update: install instrunctions for other platforms
- removed un-used replace command
- refactor r2script with fixes & fix for `DART_COMPRESSED_POINTERS` by trufae