### PR TITLE
fix: CMAKE policy CMP0177

### DIFF
--- a/blutter/CMakeLists.txt
+++ b/blutter/CMakeLists.txt
@@ -116,4 +116,6 @@ target_compile_definitions(${BINNAME} PRIVATE ${defines})
 
 target_compile_options(${BINNAME} PRIVATE ${cc_opts})
 
-install (TARGETS ${BINNAME} RUNTIME DESTINATION "${PROJECT_SOURCE_DIR}/../bin")
+cmake_path(SET DEST_DIR NORMALIZE "${PROJECT_SOURCE_DIR}/../bin")
+
+install (TARGETS ${BINNAME} RUNTIME DESTINATION ${DEST_DIR})


### PR DESCRIPTION
Normalize path before `install()`
https://cmake.org/cmake/help/latest/policy/CMP0177.html